### PR TITLE
feat: manage theme toggle aria state

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,12 @@
 <body>
     <!-- Skip to content link for accessibility -->
     <a href="#main-content" class="skip-link">Aller au contenu principal</a>
-    
+
+    <!-- Theme Toggle Button -->
+    <button id="theme-toggle" class="theme-toggle" aria-label="Basculer le thème" aria-pressed="false">
+        <span class="sr-only">Changer de thème</span>
+    </button>
+
     <!-- Particle Background -->
     <div id="particle-container" aria-hidden="true"></div>
     

--- a/script.js
+++ b/script.js
@@ -135,6 +135,28 @@ const applySimpleAnimation = (element, options) => {
     requestAnimationFrame(animate);
 };
 
+// Theme toggle setup with ARIA state management
+const setupThemeToggle = () => {
+    const toggleButton = document.getElementById('theme-toggle');
+    if (!toggleButton) return;
+
+    const htmlEl = document.documentElement;
+    const storedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+
+    htmlEl.setAttribute('data-theme', initialTheme);
+    toggleButton.setAttribute('aria-pressed', initialTheme === 'dark');
+
+    toggleButton.addEventListener('click', () => {
+        const currentTheme = htmlEl.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        htmlEl.setAttribute('data-theme', newTheme);
+        toggleButton.setAttribute('aria-pressed', newTheme === 'dark');
+        localStorage.setItem('theme', newTheme);
+    });
+};
+
 // Ultra Sophisticated Portfolio Class
 class UltraSophisticatedPortfolio {
     constructor() {
@@ -895,7 +917,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     `;
     document.head.appendChild(style);
-    
+
+    // Initialize theme toggle button
+    setupThemeToggle();
+
     // Initialize ultra-sophisticated portfolio
     const portfolio = new UltraSophisticatedPortfolio();
     


### PR DESCRIPTION
## Summary
- add theme toggle button with initial `aria-pressed` state
- sync `aria-pressed` attribute with active theme in script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68beecb53df4832c835b26de74bd1b5c